### PR TITLE
feat(tf): コンテナインスタンスに ECR の pull 権限を渡す

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -87,6 +87,21 @@ data "aws_iam_policy_document" "ecs_host" {
 
     resources = [aws_cloudwatch_log_group.app.arn]
   }
+
+  # ECR のイメージの pull を許可する
+  # https://docs.aws.amazon.com/ja_jp/AmazonECR/latest/userguide/ECR_on_ECS.html
+  statement {
+    sid = "allowPullingECRImages"
+
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:GetAuthorizationToken",
+    ]
+
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_role_policy" "ecs_host" {


### PR DESCRIPTION
ECS タスクの起動時に以下のようなエラーになるのを修正する。

```
CannotPullECRContainerError: AccessDeniedException: User: arn:aws:sts::711335948892:assumed-role/iidx_io.ecs_host/i-000a80424a1f11939 is not authorized to perform: ecr:GetAuthorizationToken on resource: * status code: 400, request id: 0c1afce3-7fa4-11e9-
```