### PR TITLE
fix(frontend): /_error が存在しないエラーを解消する

### DIFF
--- a/frontend/src/pages/_error.tsx
+++ b/frontend/src/pages/_error.tsx
@@ -1,0 +1,3 @@
+import ErrorComponent from 'next/error'
+
+export default ErrorComponent


### PR DESCRIPTION
fix #705 

エラーページの UI の実装は後回しにしてとりあえず next/error をそのまま使う