### PR TITLE
ci(): docker build 時に IIDXIO_VERSION 引数を渡す

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ commands:
           command: |
             docker build \
               --cache-from ${AWS_ECR_ACCOUNT_URL}/<< parameters.repo >>:latest \
+              --build-arg "IIDXIO_VERSION=${CIRCLE_SHA1}" \
               -f << parameters.dockerfile >> \
               -t ${AWS_ECR_ACCOUNT_URL}/<< parameters.repo >>:latest \
               << parameters.path >>


### PR DESCRIPTION
fix #707 and fix #705.