### PR TITLE
fix(): lint-staged v9 に追従する

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,29 @@
+const micromatch = require('micromatch')
+const path = require('path')
+
+module.exports = {
+  '**/*': absolutePaths => {
+    const cwd = process.cwd()
+    const relativePaths = absolutePaths.map(file => path.relative(cwd, file))
+
+    const match = micromatch.not(
+      micromatch(relativePaths, [
+        '**/*.js{,x}',
+        '**/*.ts{,x}',
+        '**/*.{s,}css',
+        '**/*.json',
+        '**/*.graphql',
+        '**/*.y{,a}ml',
+      ]),
+      ['docs/graphql/*'],
+    )
+
+    if (match.length === 0) {
+      return []
+    }
+
+    const matchStr = match.join(' ')
+
+    return [`prettier --write ${matchStr}`, `git add ${matchStr}`]
+  },
+}

--- a/package.json
+++ b/package.json
@@ -12,21 +12,6 @@
       "pre-commit": "lint-staged"
     }
   },
-  "lint-staged": {
-    "linters": {
-      "**/*.{js{,x},ts{,x},{s,}css,json,graphql,y{,a}ml}": [
-        "prettier --write",
-        "git add"
-      ],
-      "**/.babelrc": [
-        "prettier --write",
-        "git add"
-      ]
-    },
-    "ignore": [
-      "docs/graphql/*"
-    ]
-  },
   "devDependencies": {
     "husky": "3.0.0",
     "lint-staged": "9.0.2",


### PR DESCRIPTION
ignore が使えなくなったため、同様の実装をする