### PR TITLE
ci(): @types パッケージに resolutions が定義されているか確認する

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
             yarn run test:ci
             yarn run codecov --root=~/repo
 
-  prettier:
+  test-root:
     docker:
       - image: circleci/node
     steps:
@@ -150,6 +150,9 @@ jobs:
             - node_modules
           key: '{{ .Environment.CACHE_VERSION }}-yarn-{{ checksum "yarn.lock" }}'
       - run: yarn run format
+
+      # @types パッケージに resolutions が定義されているか確認する
+      - run: node .circleci/scripts/types-resolution-check.js
 
   docker-build-and-push:
     parameters:
@@ -177,7 +180,7 @@ workflows:
     jobs:
       - test-frontend
       - test-backend
-      - prettier
+      - test-root
   nightly:
     triggers:
       - schedule:
@@ -188,7 +191,7 @@ workflows:
     jobs:
       - test-frontend
       - test-backend
-      - prettier
+      - test-root
       - docker-build-and-push:
           name: build-and-push-frontend-image
           repo: iidx.io/frontend
@@ -196,7 +199,7 @@ workflows:
           requires:
             - test-frontend
             - test-backend
-            - prettier
+            - test-root
       - docker-build-and-push:
           name: build-and-push-backend-image
           repo: iidx.io/backend
@@ -204,4 +207,4 @@ workflows:
           requires:
             - test-frontend
             - test-backend
-            - prettier
+            - test-root

--- a/.circleci/scripts/types-resolution-check.js
+++ b/.circleci/scripts/types-resolution-check.js
@@ -1,0 +1,31 @@
+const fs = require('fs')
+const path = require('path')
+
+const repoRoot = path.join(__dirname, '../..')
+
+const packages = JSON.parse(
+  fs.readFileSync(path.join(repoRoot, 'frontend/package.json')),
+)
+
+const deps = { ...packages.dependencies, ...packages.devDependencies }
+const typePackages = Object.keys(deps).reduce((acc, key) => {
+  if (/^@types\//.test(key)) {
+    acc[key] = deps[key]
+  }
+
+  return acc
+}, {})
+
+const _diff = (xs, ys) => xs.filter(x => !new Set(ys).has(x))
+
+const diff = (xs, ys) => _diff(xs, ys).concat(_diff(ys, xs))
+
+const packageDiffs = diff(
+  Object.keys(typePackages),
+  Object.keys(packages.resolutions),
+)
+
+if (packageDiffs.length !== 0) {
+  console.error('missing packages:', ...packageDiffs)
+  process.exit(1)
+}


### PR DESCRIPTION
dependencies, devDependencies に @types が書かれているとき、resolutions にも書くようにしているが、書き忘れていたときに気づきにくい。その対策として、CI でチェックするようにする。