### PR TITLE
ページングをサーバーサイドでやるようにする & ローディング UI を実装

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,13 @@
+frontend/src/queries/index.tsx
+
+node_modules
+
+coverage
+.next
+/frontend/static/dist
+
+.cache
+
+.terraform
+
+docs/graphql/*

--- a/backend/app/graphql/resolvers/base.rb
+++ b/backend/app/graphql/resolvers/base.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class Base < GraphQL::Schema::Resolver
+  end
+end

--- a/backend/app/graphql/resolvers/search_maps.rb
+++ b/backend/app/graphql/resolvers/search_maps.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class SearchMaps < Resolvers::Base
+    type Types::Object::MapListType, null: false
+
+    MAX_PAGE_SIZE = 50
+
+    argument :offset, Integer, required: false
+    argument :limit, Integer, required: false
+    argument :title, String, required: false
+    argument :levels, [Integer, null: true], required: false
+    argument :play_style, Types::Enum::PlayStyle, required: false
+    argument :difficulties, [Types::Enum::Difficulty, null: true], required: false
+
+    def resolve(offset: 0, limit: MAX_PAGE_SIZE, title: '', levels: [], play_style: nil, difficulties: [])
+      maps = Map.includes(:music, :results)
+      maps = maps.where(music: Music.fuzzy_search_by_title(title)) if title.present?
+      maps = maps.where(level: levels) unless levels.empty?
+      maps = maps.where(play_style: play_style) unless play_style.nil?
+      maps = maps.where(difficulty: difficulties) unless difficulties.empty?
+
+      maps.offset(offset).limit(limit)
+    end
+  end
+end

--- a/backend/app/graphql/types/connection/map_connection.rb
+++ b/backend/app/graphql/types/connection/map_connection.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Types
+  module Connection
+    class MapConnection < GraphQL::Types::Relay::BaseConnection
+      edge_type(Types::Edge::MapEdge)
+
+      field :total_count, Integer, null: false
+
+      def total_count
+        object.nodes.size
+      end
+    end
+  end
+end

--- a/backend/app/graphql/types/edge/map_edge.rb
+++ b/backend/app/graphql/types/edge/map_edge.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Types
+  module Edge
+    class MapEdge < GraphQL::Types::Relay::BaseEdge
+      node_type(Types::Object::MapType)
+    end
+  end
+end

--- a/backend/app/graphql/types/interface/pageable.rb
+++ b/backend/app/graphql/types/interface/pageable.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Types
+  module Interface
+    module Pageable
+      include Types::Interface::Base
+
+      field :total_count, Integer, null: false
+
+      def total_count
+        object.except(:limit, :offset).count
+      end
+    end
+  end
+end

--- a/backend/app/graphql/types/object/map_list_type.rb
+++ b/backend/app/graphql/types/object/map_list_type.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Types
+  module Object
+    class MapListType < Base
+      implements Types::Interface::Pageable
+
+      field :nodes, [MapType], null: false
+
+      def nodes
+        object
+      end
+    end
+  end
+end

--- a/backend/app/graphql/types/object/query_type.rb
+++ b/backend/app/graphql/types/object/query_type.rb
@@ -50,23 +50,7 @@ module Types
         Map.includes(:music).where(level: 12, play_style: :sp)
       end
 
-      field :search_maps, [MapType], null: true do
-        description 'Search maps.'
-        argument :title, String, required: false
-        argument :levels, [Integer, null: true], required: false
-        argument :play_style, Enum::PlayStyle, required: false
-        argument :difficulties, [Enum::Difficulty, null: true], required: false
-      end
-
-      def search_maps(title: '', levels: [], play_style: nil, difficulties: [])
-        maps = Map.includes(:music, :results)
-        maps = maps.where(music: Music.fuzzy_search_by_title(title)) if title.present?
-        maps = maps.where(level: levels) unless levels.empty?
-        maps = maps.where(play_style: play_style) unless play_style.nil?
-        maps = maps.where(difficulty: difficulties) unless difficulties.empty?
-
-        maps
-      end
+      field :search_maps, resolver: Resolvers::SearchMaps, description: 'Search maps.'
     end
   end
 end

--- a/docs/graphql/schema.graphql
+++ b/docs/graphql/schema.graphql
@@ -113,6 +113,11 @@ type Map {
   result(username: String!): Result
 }
 
+type MapList implements Pageable {
+  nodes: [Map!]!
+  totalCount: Int!
+}
+
 type Music {
   artist: String!
   genre: String!
@@ -128,6 +133,10 @@ type Music {
 type Mutation {
   createUser(displayName: String, username: String!): CreateUserPayload
   registerResultsWithCSV(csv: String!, playStyle: PlayStyle!): RegisterResultsWithCSVPayload
+}
+
+interface Pageable {
+  totalCount: Int!
 }
 
 enum PlayStyle {
@@ -161,7 +170,7 @@ type Query {
   """
   Search maps.
   """
-  searchMaps(difficulties: [Difficulty], levels: [Int], playStyle: PlayStyle, title: String): [Map!]
+  searchMaps(difficulties: [Difficulty], levels: [Int], limit: Int, offset: Int, playStyle: PlayStyle, title: String): MapList!
 
   """
   Find a user by name.

--- a/docs/graphql/schema.json
+++ b/docs/graphql/schema.json
@@ -110,6 +110,26 @@
               "description": "Search maps.",
               "args": [
                 {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "title",
                   "description": null,
                   "type": {
@@ -159,16 +179,12 @@
                 }
               ],
               "type": {
-                "kind": "LIST",
+                "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "Map",
-                    "ofType": null
-                  }
+                  "kind": "OBJECT",
+                  "name": "MapList",
+                  "ofType": null
                 }
               },
               "isDeprecated": false,
@@ -1041,6 +1057,102 @@
             }
           ],
           "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "MapList",
+          "description": null,
+          "fields": [
+            {
+              "name": "nodes",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Map",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Pageable",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "Pageable",
+          "description": null,
+          "fields": [
+            {
+              "name": "totalCount",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "MapList",
+              "ofType": null
+            }
+          ]
         },
         {
           "kind": "OBJECT",

--- a/frontend/__tests__/components/organisms/ResultList.test.tsx
+++ b/frontend/__tests__/components/organisms/ResultList.test.tsx
@@ -30,7 +30,9 @@ const request = {
 
 describe('ResultList', () => {
   it('renders correctly', async () => {
-    const data: GetUserResultsQuery = { searchMaps: [] }
+    const data: GetUserResultsQuery = {
+      searchMaps: { totalCount: 0, nodes: [] },
+    }
 
     const mocks = [{ request, result: { data } }]
 
@@ -53,7 +55,9 @@ describe('ResultList', () => {
   })
 
   it('renders correctly when loading', async () => {
-    const data: GetUserResultsQuery = { searchMaps: [] }
+    const data: GetUserResultsQuery = {
+      searchMaps: { totalCount: 0, nodes: [] },
+    }
 
     const mocks = [{ request, result: { data } }]
 

--- a/frontend/__tests__/components/organisms/__snapshots__/ResultList.test.tsx.snap
+++ b/frontend/__tests__/components/organisms/__snapshots__/ResultList.test.tsx.snap
@@ -174,7 +174,2176 @@ exports[`ResultList renders correctly when loading 1`] = `
     <div
       className="table-wrapper"
     >
-      loading
+      <div
+        className="pagination top"
+      />
+      <div
+        className="result-table"
+      >
+        <div
+          className="card"
+        >
+          <div
+            className="card "
+          >
+            <div
+              className="card-header"
+            >
+              <div
+                className="header"
+              >
+                <div
+                  className="label loading"
+                >
+                  -
+                </div>
+                <div
+                  className="title loading"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                className="data-box-wrapper"
+              >
+                <div
+                  className="clear-lamp loading"
+                />
+                <div
+                  className="data-box"
+                >
+                  <div
+                    className="data-box-content"
+                  >
+                    <div
+                      className="score-box-wrapper"
+                    >
+                      <dl
+                        className="score-box"
+                      >
+                        <div
+                          className="data-list ex-score"
+                        >
+                          <dt>
+                            EX-SCORE
+                          </dt>
+                          <dd>
+                            <span
+                              className="score-text loading"
+                            />
+                            <span
+                              className="score-rate loading"
+                            />
+                          </dd>
+                        </div>
+                        <div
+                          className="wrapper loading"
+                        />
+                      </dl>
+                      <div
+                        className="additional-area"
+                      >
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            BPI
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list clear-type"
+                        >
+                          <dt>
+                            CLEAR TYPE
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            LAST PLAY
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                      </div>
+                    </div>
+                    <div
+                      className="symbol-area"
+                    >
+                      <div
+                        className="grade-box loading"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="card"
+        >
+          <div
+            className="card "
+          >
+            <div
+              className="card-header"
+            >
+              <div
+                className="header"
+              >
+                <div
+                  className="label loading"
+                >
+                  -
+                </div>
+                <div
+                  className="title loading"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                className="data-box-wrapper"
+              >
+                <div
+                  className="clear-lamp loading"
+                />
+                <div
+                  className="data-box"
+                >
+                  <div
+                    className="data-box-content"
+                  >
+                    <div
+                      className="score-box-wrapper"
+                    >
+                      <dl
+                        className="score-box"
+                      >
+                        <div
+                          className="data-list ex-score"
+                        >
+                          <dt>
+                            EX-SCORE
+                          </dt>
+                          <dd>
+                            <span
+                              className="score-text loading"
+                            />
+                            <span
+                              className="score-rate loading"
+                            />
+                          </dd>
+                        </div>
+                        <div
+                          className="wrapper loading"
+                        />
+                      </dl>
+                      <div
+                        className="additional-area"
+                      >
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            BPI
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list clear-type"
+                        >
+                          <dt>
+                            CLEAR TYPE
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            LAST PLAY
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                      </div>
+                    </div>
+                    <div
+                      className="symbol-area"
+                    >
+                      <div
+                        className="grade-box loading"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="card"
+        >
+          <div
+            className="card "
+          >
+            <div
+              className="card-header"
+            >
+              <div
+                className="header"
+              >
+                <div
+                  className="label loading"
+                >
+                  -
+                </div>
+                <div
+                  className="title loading"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                className="data-box-wrapper"
+              >
+                <div
+                  className="clear-lamp loading"
+                />
+                <div
+                  className="data-box"
+                >
+                  <div
+                    className="data-box-content"
+                  >
+                    <div
+                      className="score-box-wrapper"
+                    >
+                      <dl
+                        className="score-box"
+                      >
+                        <div
+                          className="data-list ex-score"
+                        >
+                          <dt>
+                            EX-SCORE
+                          </dt>
+                          <dd>
+                            <span
+                              className="score-text loading"
+                            />
+                            <span
+                              className="score-rate loading"
+                            />
+                          </dd>
+                        </div>
+                        <div
+                          className="wrapper loading"
+                        />
+                      </dl>
+                      <div
+                        className="additional-area"
+                      >
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            BPI
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list clear-type"
+                        >
+                          <dt>
+                            CLEAR TYPE
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            LAST PLAY
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                      </div>
+                    </div>
+                    <div
+                      className="symbol-area"
+                    >
+                      <div
+                        className="grade-box loading"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="card"
+        >
+          <div
+            className="card "
+          >
+            <div
+              className="card-header"
+            >
+              <div
+                className="header"
+              >
+                <div
+                  className="label loading"
+                >
+                  -
+                </div>
+                <div
+                  className="title loading"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                className="data-box-wrapper"
+              >
+                <div
+                  className="clear-lamp loading"
+                />
+                <div
+                  className="data-box"
+                >
+                  <div
+                    className="data-box-content"
+                  >
+                    <div
+                      className="score-box-wrapper"
+                    >
+                      <dl
+                        className="score-box"
+                      >
+                        <div
+                          className="data-list ex-score"
+                        >
+                          <dt>
+                            EX-SCORE
+                          </dt>
+                          <dd>
+                            <span
+                              className="score-text loading"
+                            />
+                            <span
+                              className="score-rate loading"
+                            />
+                          </dd>
+                        </div>
+                        <div
+                          className="wrapper loading"
+                        />
+                      </dl>
+                      <div
+                        className="additional-area"
+                      >
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            BPI
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list clear-type"
+                        >
+                          <dt>
+                            CLEAR TYPE
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            LAST PLAY
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                      </div>
+                    </div>
+                    <div
+                      className="symbol-area"
+                    >
+                      <div
+                        className="grade-box loading"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="card"
+        >
+          <div
+            className="card "
+          >
+            <div
+              className="card-header"
+            >
+              <div
+                className="header"
+              >
+                <div
+                  className="label loading"
+                >
+                  -
+                </div>
+                <div
+                  className="title loading"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                className="data-box-wrapper"
+              >
+                <div
+                  className="clear-lamp loading"
+                />
+                <div
+                  className="data-box"
+                >
+                  <div
+                    className="data-box-content"
+                  >
+                    <div
+                      className="score-box-wrapper"
+                    >
+                      <dl
+                        className="score-box"
+                      >
+                        <div
+                          className="data-list ex-score"
+                        >
+                          <dt>
+                            EX-SCORE
+                          </dt>
+                          <dd>
+                            <span
+                              className="score-text loading"
+                            />
+                            <span
+                              className="score-rate loading"
+                            />
+                          </dd>
+                        </div>
+                        <div
+                          className="wrapper loading"
+                        />
+                      </dl>
+                      <div
+                        className="additional-area"
+                      >
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            BPI
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list clear-type"
+                        >
+                          <dt>
+                            CLEAR TYPE
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            LAST PLAY
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                      </div>
+                    </div>
+                    <div
+                      className="symbol-area"
+                    >
+                      <div
+                        className="grade-box loading"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="card"
+        >
+          <div
+            className="card "
+          >
+            <div
+              className="card-header"
+            >
+              <div
+                className="header"
+              >
+                <div
+                  className="label loading"
+                >
+                  -
+                </div>
+                <div
+                  className="title loading"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                className="data-box-wrapper"
+              >
+                <div
+                  className="clear-lamp loading"
+                />
+                <div
+                  className="data-box"
+                >
+                  <div
+                    className="data-box-content"
+                  >
+                    <div
+                      className="score-box-wrapper"
+                    >
+                      <dl
+                        className="score-box"
+                      >
+                        <div
+                          className="data-list ex-score"
+                        >
+                          <dt>
+                            EX-SCORE
+                          </dt>
+                          <dd>
+                            <span
+                              className="score-text loading"
+                            />
+                            <span
+                              className="score-rate loading"
+                            />
+                          </dd>
+                        </div>
+                        <div
+                          className="wrapper loading"
+                        />
+                      </dl>
+                      <div
+                        className="additional-area"
+                      >
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            BPI
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list clear-type"
+                        >
+                          <dt>
+                            CLEAR TYPE
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            LAST PLAY
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                      </div>
+                    </div>
+                    <div
+                      className="symbol-area"
+                    >
+                      <div
+                        className="grade-box loading"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="card"
+        >
+          <div
+            className="card "
+          >
+            <div
+              className="card-header"
+            >
+              <div
+                className="header"
+              >
+                <div
+                  className="label loading"
+                >
+                  -
+                </div>
+                <div
+                  className="title loading"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                className="data-box-wrapper"
+              >
+                <div
+                  className="clear-lamp loading"
+                />
+                <div
+                  className="data-box"
+                >
+                  <div
+                    className="data-box-content"
+                  >
+                    <div
+                      className="score-box-wrapper"
+                    >
+                      <dl
+                        className="score-box"
+                      >
+                        <div
+                          className="data-list ex-score"
+                        >
+                          <dt>
+                            EX-SCORE
+                          </dt>
+                          <dd>
+                            <span
+                              className="score-text loading"
+                            />
+                            <span
+                              className="score-rate loading"
+                            />
+                          </dd>
+                        </div>
+                        <div
+                          className="wrapper loading"
+                        />
+                      </dl>
+                      <div
+                        className="additional-area"
+                      >
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            BPI
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list clear-type"
+                        >
+                          <dt>
+                            CLEAR TYPE
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            LAST PLAY
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                      </div>
+                    </div>
+                    <div
+                      className="symbol-area"
+                    >
+                      <div
+                        className="grade-box loading"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="card"
+        >
+          <div
+            className="card "
+          >
+            <div
+              className="card-header"
+            >
+              <div
+                className="header"
+              >
+                <div
+                  className="label loading"
+                >
+                  -
+                </div>
+                <div
+                  className="title loading"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                className="data-box-wrapper"
+              >
+                <div
+                  className="clear-lamp loading"
+                />
+                <div
+                  className="data-box"
+                >
+                  <div
+                    className="data-box-content"
+                  >
+                    <div
+                      className="score-box-wrapper"
+                    >
+                      <dl
+                        className="score-box"
+                      >
+                        <div
+                          className="data-list ex-score"
+                        >
+                          <dt>
+                            EX-SCORE
+                          </dt>
+                          <dd>
+                            <span
+                              className="score-text loading"
+                            />
+                            <span
+                              className="score-rate loading"
+                            />
+                          </dd>
+                        </div>
+                        <div
+                          className="wrapper loading"
+                        />
+                      </dl>
+                      <div
+                        className="additional-area"
+                      >
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            BPI
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list clear-type"
+                        >
+                          <dt>
+                            CLEAR TYPE
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            LAST PLAY
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                      </div>
+                    </div>
+                    <div
+                      className="symbol-area"
+                    >
+                      <div
+                        className="grade-box loading"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="card"
+        >
+          <div
+            className="card "
+          >
+            <div
+              className="card-header"
+            >
+              <div
+                className="header"
+              >
+                <div
+                  className="label loading"
+                >
+                  -
+                </div>
+                <div
+                  className="title loading"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                className="data-box-wrapper"
+              >
+                <div
+                  className="clear-lamp loading"
+                />
+                <div
+                  className="data-box"
+                >
+                  <div
+                    className="data-box-content"
+                  >
+                    <div
+                      className="score-box-wrapper"
+                    >
+                      <dl
+                        className="score-box"
+                      >
+                        <div
+                          className="data-list ex-score"
+                        >
+                          <dt>
+                            EX-SCORE
+                          </dt>
+                          <dd>
+                            <span
+                              className="score-text loading"
+                            />
+                            <span
+                              className="score-rate loading"
+                            />
+                          </dd>
+                        </div>
+                        <div
+                          className="wrapper loading"
+                        />
+                      </dl>
+                      <div
+                        className="additional-area"
+                      >
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            BPI
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list clear-type"
+                        >
+                          <dt>
+                            CLEAR TYPE
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            LAST PLAY
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                      </div>
+                    </div>
+                    <div
+                      className="symbol-area"
+                    >
+                      <div
+                        className="grade-box loading"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="card"
+        >
+          <div
+            className="card "
+          >
+            <div
+              className="card-header"
+            >
+              <div
+                className="header"
+              >
+                <div
+                  className="label loading"
+                >
+                  -
+                </div>
+                <div
+                  className="title loading"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                className="data-box-wrapper"
+              >
+                <div
+                  className="clear-lamp loading"
+                />
+                <div
+                  className="data-box"
+                >
+                  <div
+                    className="data-box-content"
+                  >
+                    <div
+                      className="score-box-wrapper"
+                    >
+                      <dl
+                        className="score-box"
+                      >
+                        <div
+                          className="data-list ex-score"
+                        >
+                          <dt>
+                            EX-SCORE
+                          </dt>
+                          <dd>
+                            <span
+                              className="score-text loading"
+                            />
+                            <span
+                              className="score-rate loading"
+                            />
+                          </dd>
+                        </div>
+                        <div
+                          className="wrapper loading"
+                        />
+                      </dl>
+                      <div
+                        className="additional-area"
+                      >
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            BPI
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list clear-type"
+                        >
+                          <dt>
+                            CLEAR TYPE
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            LAST PLAY
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                      </div>
+                    </div>
+                    <div
+                      className="symbol-area"
+                    >
+                      <div
+                        className="grade-box loading"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="card"
+        >
+          <div
+            className="card "
+          >
+            <div
+              className="card-header"
+            >
+              <div
+                className="header"
+              >
+                <div
+                  className="label loading"
+                >
+                  -
+                </div>
+                <div
+                  className="title loading"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                className="data-box-wrapper"
+              >
+                <div
+                  className="clear-lamp loading"
+                />
+                <div
+                  className="data-box"
+                >
+                  <div
+                    className="data-box-content"
+                  >
+                    <div
+                      className="score-box-wrapper"
+                    >
+                      <dl
+                        className="score-box"
+                      >
+                        <div
+                          className="data-list ex-score"
+                        >
+                          <dt>
+                            EX-SCORE
+                          </dt>
+                          <dd>
+                            <span
+                              className="score-text loading"
+                            />
+                            <span
+                              className="score-rate loading"
+                            />
+                          </dd>
+                        </div>
+                        <div
+                          className="wrapper loading"
+                        />
+                      </dl>
+                      <div
+                        className="additional-area"
+                      >
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            BPI
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list clear-type"
+                        >
+                          <dt>
+                            CLEAR TYPE
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            LAST PLAY
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                      </div>
+                    </div>
+                    <div
+                      className="symbol-area"
+                    >
+                      <div
+                        className="grade-box loading"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="card"
+        >
+          <div
+            className="card "
+          >
+            <div
+              className="card-header"
+            >
+              <div
+                className="header"
+              >
+                <div
+                  className="label loading"
+                >
+                  -
+                </div>
+                <div
+                  className="title loading"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                className="data-box-wrapper"
+              >
+                <div
+                  className="clear-lamp loading"
+                />
+                <div
+                  className="data-box"
+                >
+                  <div
+                    className="data-box-content"
+                  >
+                    <div
+                      className="score-box-wrapper"
+                    >
+                      <dl
+                        className="score-box"
+                      >
+                        <div
+                          className="data-list ex-score"
+                        >
+                          <dt>
+                            EX-SCORE
+                          </dt>
+                          <dd>
+                            <span
+                              className="score-text loading"
+                            />
+                            <span
+                              className="score-rate loading"
+                            />
+                          </dd>
+                        </div>
+                        <div
+                          className="wrapper loading"
+                        />
+                      </dl>
+                      <div
+                        className="additional-area"
+                      >
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            BPI
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list clear-type"
+                        >
+                          <dt>
+                            CLEAR TYPE
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            LAST PLAY
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                      </div>
+                    </div>
+                    <div
+                      className="symbol-area"
+                    >
+                      <div
+                        className="grade-box loading"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="card"
+        >
+          <div
+            className="card "
+          >
+            <div
+              className="card-header"
+            >
+              <div
+                className="header"
+              >
+                <div
+                  className="label loading"
+                >
+                  -
+                </div>
+                <div
+                  className="title loading"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                className="data-box-wrapper"
+              >
+                <div
+                  className="clear-lamp loading"
+                />
+                <div
+                  className="data-box"
+                >
+                  <div
+                    className="data-box-content"
+                  >
+                    <div
+                      className="score-box-wrapper"
+                    >
+                      <dl
+                        className="score-box"
+                      >
+                        <div
+                          className="data-list ex-score"
+                        >
+                          <dt>
+                            EX-SCORE
+                          </dt>
+                          <dd>
+                            <span
+                              className="score-text loading"
+                            />
+                            <span
+                              className="score-rate loading"
+                            />
+                          </dd>
+                        </div>
+                        <div
+                          className="wrapper loading"
+                        />
+                      </dl>
+                      <div
+                        className="additional-area"
+                      >
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            BPI
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list clear-type"
+                        >
+                          <dt>
+                            CLEAR TYPE
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            LAST PLAY
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                      </div>
+                    </div>
+                    <div
+                      className="symbol-area"
+                    >
+                      <div
+                        className="grade-box loading"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="card"
+        >
+          <div
+            className="card "
+          >
+            <div
+              className="card-header"
+            >
+              <div
+                className="header"
+              >
+                <div
+                  className="label loading"
+                >
+                  -
+                </div>
+                <div
+                  className="title loading"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                className="data-box-wrapper"
+              >
+                <div
+                  className="clear-lamp loading"
+                />
+                <div
+                  className="data-box"
+                >
+                  <div
+                    className="data-box-content"
+                  >
+                    <div
+                      className="score-box-wrapper"
+                    >
+                      <dl
+                        className="score-box"
+                      >
+                        <div
+                          className="data-list ex-score"
+                        >
+                          <dt>
+                            EX-SCORE
+                          </dt>
+                          <dd>
+                            <span
+                              className="score-text loading"
+                            />
+                            <span
+                              className="score-rate loading"
+                            />
+                          </dd>
+                        </div>
+                        <div
+                          className="wrapper loading"
+                        />
+                      </dl>
+                      <div
+                        className="additional-area"
+                      >
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            BPI
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list clear-type"
+                        >
+                          <dt>
+                            CLEAR TYPE
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            LAST PLAY
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                      </div>
+                    </div>
+                    <div
+                      className="symbol-area"
+                    >
+                      <div
+                        className="grade-box loading"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="card"
+        >
+          <div
+            className="card "
+          >
+            <div
+              className="card-header"
+            >
+              <div
+                className="header"
+              >
+                <div
+                  className="label loading"
+                >
+                  -
+                </div>
+                <div
+                  className="title loading"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                className="data-box-wrapper"
+              >
+                <div
+                  className="clear-lamp loading"
+                />
+                <div
+                  className="data-box"
+                >
+                  <div
+                    className="data-box-content"
+                  >
+                    <div
+                      className="score-box-wrapper"
+                    >
+                      <dl
+                        className="score-box"
+                      >
+                        <div
+                          className="data-list ex-score"
+                        >
+                          <dt>
+                            EX-SCORE
+                          </dt>
+                          <dd>
+                            <span
+                              className="score-text loading"
+                            />
+                            <span
+                              className="score-rate loading"
+                            />
+                          </dd>
+                        </div>
+                        <div
+                          className="wrapper loading"
+                        />
+                      </dl>
+                      <div
+                        className="additional-area"
+                      >
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            BPI
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list clear-type"
+                        >
+                          <dt>
+                            CLEAR TYPE
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            LAST PLAY
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                      </div>
+                    </div>
+                    <div
+                      className="symbol-area"
+                    >
+                      <div
+                        className="grade-box loading"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="card"
+        >
+          <div
+            className="card "
+          >
+            <div
+              className="card-header"
+            >
+              <div
+                className="header"
+              >
+                <div
+                  className="label loading"
+                >
+                  -
+                </div>
+                <div
+                  className="title loading"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                className="data-box-wrapper"
+              >
+                <div
+                  className="clear-lamp loading"
+                />
+                <div
+                  className="data-box"
+                >
+                  <div
+                    className="data-box-content"
+                  >
+                    <div
+                      className="score-box-wrapper"
+                    >
+                      <dl
+                        className="score-box"
+                      >
+                        <div
+                          className="data-list ex-score"
+                        >
+                          <dt>
+                            EX-SCORE
+                          </dt>
+                          <dd>
+                            <span
+                              className="score-text loading"
+                            />
+                            <span
+                              className="score-rate loading"
+                            />
+                          </dd>
+                        </div>
+                        <div
+                          className="wrapper loading"
+                        />
+                      </dl>
+                      <div
+                        className="additional-area"
+                      >
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            BPI
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list clear-type"
+                        >
+                          <dt>
+                            CLEAR TYPE
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            LAST PLAY
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                      </div>
+                    </div>
+                    <div
+                      className="symbol-area"
+                    >
+                      <div
+                        className="grade-box loading"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="card"
+        >
+          <div
+            className="card "
+          >
+            <div
+              className="card-header"
+            >
+              <div
+                className="header"
+              >
+                <div
+                  className="label loading"
+                >
+                  -
+                </div>
+                <div
+                  className="title loading"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                className="data-box-wrapper"
+              >
+                <div
+                  className="clear-lamp loading"
+                />
+                <div
+                  className="data-box"
+                >
+                  <div
+                    className="data-box-content"
+                  >
+                    <div
+                      className="score-box-wrapper"
+                    >
+                      <dl
+                        className="score-box"
+                      >
+                        <div
+                          className="data-list ex-score"
+                        >
+                          <dt>
+                            EX-SCORE
+                          </dt>
+                          <dd>
+                            <span
+                              className="score-text loading"
+                            />
+                            <span
+                              className="score-rate loading"
+                            />
+                          </dd>
+                        </div>
+                        <div
+                          className="wrapper loading"
+                        />
+                      </dl>
+                      <div
+                        className="additional-area"
+                      >
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            BPI
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list clear-type"
+                        >
+                          <dt>
+                            CLEAR TYPE
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            LAST PLAY
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                      </div>
+                    </div>
+                    <div
+                      className="symbol-area"
+                    >
+                      <div
+                        className="grade-box loading"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="card"
+        >
+          <div
+            className="card "
+          >
+            <div
+              className="card-header"
+            >
+              <div
+                className="header"
+              >
+                <div
+                  className="label loading"
+                >
+                  -
+                </div>
+                <div
+                  className="title loading"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                className="data-box-wrapper"
+              >
+                <div
+                  className="clear-lamp loading"
+                />
+                <div
+                  className="data-box"
+                >
+                  <div
+                    className="data-box-content"
+                  >
+                    <div
+                      className="score-box-wrapper"
+                    >
+                      <dl
+                        className="score-box"
+                      >
+                        <div
+                          className="data-list ex-score"
+                        >
+                          <dt>
+                            EX-SCORE
+                          </dt>
+                          <dd>
+                            <span
+                              className="score-text loading"
+                            />
+                            <span
+                              className="score-rate loading"
+                            />
+                          </dd>
+                        </div>
+                        <div
+                          className="wrapper loading"
+                        />
+                      </dl>
+                      <div
+                        className="additional-area"
+                      >
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            BPI
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list clear-type"
+                        >
+                          <dt>
+                            CLEAR TYPE
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            LAST PLAY
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                      </div>
+                    </div>
+                    <div
+                      className="symbol-area"
+                    >
+                      <div
+                        className="grade-box loading"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="card"
+        >
+          <div
+            className="card "
+          >
+            <div
+              className="card-header"
+            >
+              <div
+                className="header"
+              >
+                <div
+                  className="label loading"
+                >
+                  -
+                </div>
+                <div
+                  className="title loading"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                className="data-box-wrapper"
+              >
+                <div
+                  className="clear-lamp loading"
+                />
+                <div
+                  className="data-box"
+                >
+                  <div
+                    className="data-box-content"
+                  >
+                    <div
+                      className="score-box-wrapper"
+                    >
+                      <dl
+                        className="score-box"
+                      >
+                        <div
+                          className="data-list ex-score"
+                        >
+                          <dt>
+                            EX-SCORE
+                          </dt>
+                          <dd>
+                            <span
+                              className="score-text loading"
+                            />
+                            <span
+                              className="score-rate loading"
+                            />
+                          </dd>
+                        </div>
+                        <div
+                          className="wrapper loading"
+                        />
+                      </dl>
+                      <div
+                        className="additional-area"
+                      >
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            BPI
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list clear-type"
+                        >
+                          <dt>
+                            CLEAR TYPE
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            LAST PLAY
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                      </div>
+                    </div>
+                    <div
+                      className="symbol-area"
+                    >
+                      <div
+                        className="grade-box loading"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="card"
+        >
+          <div
+            className="card "
+          >
+            <div
+              className="card-header"
+            >
+              <div
+                className="header"
+              >
+                <div
+                  className="label loading"
+                >
+                  -
+                </div>
+                <div
+                  className="title loading"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                className="data-box-wrapper"
+              >
+                <div
+                  className="clear-lamp loading"
+                />
+                <div
+                  className="data-box"
+                >
+                  <div
+                    className="data-box-content"
+                  >
+                    <div
+                      className="score-box-wrapper"
+                    >
+                      <dl
+                        className="score-box"
+                      >
+                        <div
+                          className="data-list ex-score"
+                        >
+                          <dt>
+                            EX-SCORE
+                          </dt>
+                          <dd>
+                            <span
+                              className="score-text loading"
+                            />
+                            <span
+                              className="score-rate loading"
+                            />
+                          </dd>
+                        </div>
+                        <div
+                          className="wrapper loading"
+                        />
+                      </dl>
+                      <div
+                        className="additional-area"
+                      >
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            BPI
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list clear-type"
+                        >
+                          <dt>
+                            CLEAR TYPE
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                        <dl
+                          className="data-list"
+                        >
+                          <dt>
+                            LAST PLAY
+                          </dt>
+                          <dd>
+                            -
+                          </dd>
+                        </dl>
+                      </div>
+                    </div>
+                    <div
+                      className="symbol-area"
+                    >
+                      <div
+                        className="grade-box loading"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="pagination bottom"
+      />
     </div>
   </div>
 </div>

--- a/frontend/src/components/atoms/Card/index.tsx
+++ b/frontend/src/components/atoms/Card/index.tsx
@@ -9,14 +9,16 @@ export interface Props {
   header: React.ReactNode
   content: React.ReactNode
   className?: string
+  clickable?: boolean
 }
 
 const Card: React.FunctionComponent<Props> = ({
   header,
   content,
   className,
+  clickable = true,
 }) => (
-  <div className={[cx('card'), className].join(' ')}>
+  <div className={[cx('card', { clickable }), className].join(' ')}>
     <div className={cx('card-header')}>{header}</div>
     <div>{content}</div>
   </div>

--- a/frontend/src/components/atoms/Card/style.scss
+++ b/frontend/src/components/atoms/Card/style.scss
@@ -16,7 +16,7 @@ $clear-lamp-width: 0.6rem;
 
   background-color: $primary-bg-color;
 
-  &:hover {
+  &.clickable:hover {
     background-color: darken($primary-bg-color, 3%);
     cursor: pointer;
   }

--- a/frontend/src/components/atoms/ScoreGraph/index.tsx
+++ b/frontend/src/components/atoms/ScoreGraph/index.tsx
@@ -6,32 +6,44 @@ import * as css from './style.scss'
 
 const cx = classnames.bind(css)
 
-export interface Props {
-  grade: Grade | null
-  scoreRate: number
-  fullCombo: boolean
-}
+export type Props =
+  | {
+      loading?: false
+      grade: Grade | null
+      scoreRate: number
+      fullCombo: boolean
+    }
+  | {
+      loading: true
+    }
 
-const ScoreGraph: React.SFC<Props> = ({ grade, scoreRate, fullCombo }) => (
-  <div className={cx('wrapper')}>
-    <div
-      className={cx('progress', {
-        'grade-aaa': grade === Grade.AAA,
-        'grade-aa': grade === Grade.AA,
-        'grade-a': grade === Grade.A,
-        'grade-b': grade === Grade.B,
-        'grade-c': grade === Grade.C,
-        'grade-d': grade === Grade.D,
-        'grade-e': grade === Grade.E,
-        'grade-f': grade === Grade.F,
-        'full-combo': fullCombo,
-      })}
-      style={{ width: `${scoreRate}%` }}
-    />
-    <div className={cx('target', 'grade-a')} />
-    <div className={cx('target', 'grade-aa')} />
-    <div className={cx('target', 'grade-aaa')} />
-  </div>
-)
+const ScoreGraph: React.SFC<Props> = props => {
+  if (props.loading) {
+    return <div className={cx('wrapper', 'loading')} />
+  } else {
+    const { grade, scoreRate, fullCombo } = props
+    return (
+      <div className={cx('wrapper')}>
+        <div
+          className={cx('progress', {
+            'grade-aaa': grade === Grade.AAA,
+            'grade-aa': grade === Grade.AA,
+            'grade-a': grade === Grade.A,
+            'grade-b': grade === Grade.B,
+            'grade-c': grade === Grade.C,
+            'grade-d': grade === Grade.D,
+            'grade-e': grade === Grade.E,
+            'grade-f': grade === Grade.F,
+            'full-combo': fullCombo,
+          })}
+          style={{ width: `${scoreRate}%` }}
+        />
+        <div className={cx('target', 'grade-a')} />
+        <div className={cx('target', 'grade-aa')} />
+        <div className={cx('target', 'grade-aaa')} />
+      </div>
+    )
+  }
+}
 
 export default ScoreGraph

--- a/frontend/src/components/atoms/ScoreGraph/style.scss
+++ b/frontend/src/components/atoms/ScoreGraph/style.scss
@@ -1,4 +1,5 @@
 @import 'styles/colors';
+@import 'styles/mixins';
 
 $bar-height: 0.6rem;
 
@@ -75,4 +76,10 @@ $bar-height: 0.6rem;
       width: 8/9 * 100 * 1%;
     }
   }
+}
+
+.loading {
+  @include skeleton-loading;
+
+  height: $bar-height;
 }

--- a/frontend/src/components/molecules/ResultBox/index.tsx
+++ b/frontend/src/components/molecules/ResultBox/index.tsx
@@ -28,11 +28,20 @@ export type Map = {
   numNotes: number
 }
 
+type Data =
+  | {
+      loading: true
+    }
+  | {
+      loading: false
+      result?: Result | null
+      map: Map
+    }
+
 export interface Props {
   showBPI?: boolean
-  result?: Result | null
-  map: Map
   href?: string
+  data: Data
 }
 
 const clearTypeTexts: { [key in ClearLamp]: string } = {
@@ -47,123 +56,183 @@ const clearTypeTexts: { [key in ClearLamp]: string } = {
 
 const ResultBox: React.FunctionComponent<Props> = ({
   showBPI = false,
-  result,
-  map,
+  data,
   href,
 }) => {
-  const current =
-    result && result.score != null
-      ? searchGrade(result.score, map.numNotes)
-      : defaultGradeDiff
-  const next =
-    result && result.score != null
-      ? searchNextGrade(result.score, map.numNotes)
-      : defaultGradeDiff
+  if (data.loading) {
+    return (
+      <div className={cx('data-box-wrapper')}>
+        <div className={cx('clear-lamp', 'loading')} />
+        <div className={cx('data-box')}>
+          <div className={cx('data-box-content')}>
+            <div className={cx('score-box-wrapper')}>
+              <dl className={cx('score-box')}>
+                <div className={cx('data-list', 'ex-score')}>
+                  <dt>EX-SCORE</dt>
+                  <dd>
+                    <span className={cx('score-text', 'loading')} />
+                    <span className={cx('score-rate', 'loading')} />
+                  </dd>
+                </div>
+                <ScoreGraph loading />
+              </dl>
 
-  const scoreRate =
-    result && result.score != null
-      ? calcScoreRate(result.score, map.numNotes)
-      : 0
-  return (
-    <div className={cx('data-box-wrapper')}>
-      <div
-        className={cx('clear-lamp', {
-          'full-combo': result && result.clearLamp === ClearLamp.FullCombo,
-          'ex-hard-clear': result && result.clearLamp === ClearLamp.ExHard,
-          'hard-clear': result && result.clearLamp === ClearLamp.Hard,
-          clear: result && result.clearLamp === ClearLamp.Normal,
-          'easy-clear': result && result.clearLamp === ClearLamp.Easy,
-          'assist-clear': result && result.clearLamp === ClearLamp.Assist,
-          failed: result && result.clearLamp === ClearLamp.Failed,
-        })}
-      />
-      <div className={cx('data-box')}>
-        <div className={cx('data-box-content')}>
-          <div className={cx('score-box-wrapper')}>
-            <dl className={cx('score-box')}>
-              <div className={cx('data-list', 'ex-score')}>
-                <dt>EX-SCORE</dt>
-                <dd>
-                  <span className={cx('score-text')}>
-                    {result && result.score != null ? result.score : '-'}
-                  </span>
-                  <span className={cx('score-rate')}>
-                    ({scoreRate.toFixed(2)} %)
-                  </span>
-                </dd>
-              </div>
-              <ScoreGraph
-                grade={current.grade}
-                scoreRate={scoreRate}
-                fullCombo={
-                  !!(result && result.clearLamp === ClearLamp.FullCombo)
-                }
-              />
-            </dl>
+              <div className={cx('additional-area')}>
+                {showBPI && (
+                  <dl className={cx('data-list')}>
+                    <dt>BPI</dt>
+                    <dd>-</dd>
+                  </dl>
+                )}
 
-            <div className={cx('additional-area')}>
-              {showBPI && (
+                <dl className={cx('data-list', 'clear-type')}>
+                  <dt>CLEAR TYPE</dt>
+                  <dd>-</dd>
+                </dl>
+
                 <dl className={cx('data-list')}>
-                  <dt>BPI</dt>
-                  <dd className={cx('bpi')}>
-                    {result && result.bpi != null ? result.bpi.toFixed(2) : '-'}
+                  <dt>LAST PLAY</dt>
+                  <dd>-</dd>
+                </dl>
+              </div>
+            </div>
+
+            <div className={cx('symbol-area')}>
+              <div className={cx('grade-box', 'loading')} />
+            </div>
+          </div>
+
+          {href && (
+            <Link href={href}>
+              <a>
+                <FontAwesomeIcon icon={faAngleRight} />
+              </a>
+            </Link>
+          )}
+        </div>
+      </div>
+    )
+  } else {
+    const { result, map } = data
+
+    const current =
+      result && result.score != null
+        ? searchGrade(result.score, map.numNotes)
+        : defaultGradeDiff
+    const next =
+      result && result.score != null
+        ? searchNextGrade(result.score, map.numNotes)
+        : defaultGradeDiff
+
+    const scoreRate =
+      result && result.score != null
+        ? calcScoreRate(result.score, map.numNotes)
+        : 0
+    return (
+      <div className={cx('data-box-wrapper')}>
+        <div
+          className={cx('clear-lamp', {
+            'full-combo': result && result.clearLamp === ClearLamp.FullCombo,
+            'ex-hard-clear': result && result.clearLamp === ClearLamp.ExHard,
+            'hard-clear': result && result.clearLamp === ClearLamp.Hard,
+            clear: result && result.clearLamp === ClearLamp.Normal,
+            'easy-clear': result && result.clearLamp === ClearLamp.Easy,
+            'assist-clear': result && result.clearLamp === ClearLamp.Assist,
+            failed: result && result.clearLamp === ClearLamp.Failed,
+          })}
+        />
+        <div className={cx('data-box')}>
+          <div className={cx('data-box-content')}>
+            <div className={cx('score-box-wrapper')}>
+              <dl className={cx('score-box')}>
+                <div className={cx('data-list', 'ex-score')}>
+                  <dt>EX-SCORE</dt>
+                  <dd>
+                    <span className={cx('score-text')}>
+                      {result && result.score != null ? result.score : '-'}
+                    </span>
+                    <span className={cx('score-rate')}>
+                      ({scoreRate.toFixed(2)} %)
+                    </span>
+                  </dd>
+                </div>
+                <ScoreGraph
+                  grade={current.grade}
+                  scoreRate={scoreRate}
+                  fullCombo={
+                    !!(result && result.clearLamp === ClearLamp.FullCombo)
+                  }
+                />
+              </dl>
+
+              <div className={cx('additional-area')}>
+                {showBPI && (
+                  <dl className={cx('data-list')}>
+                    <dt>BPI</dt>
+                    <dd className={cx('bpi')}>
+                      {result && result.bpi != null
+                        ? result.bpi.toFixed(2)
+                        : '-'}
+                    </dd>
+                  </dl>
+                )}
+
+                <dl className={cx('data-list', 'clear-type')}>
+                  <dt>CLEAR TYPE</dt>
+                  <dd
+                    className={cx({
+                      'full-combo':
+                        result && result.clearLamp === ClearLamp.FullCombo,
+                      'ex-hard-clear':
+                        result && result.clearLamp === ClearLamp.ExHard,
+                      'hard-clear':
+                        result && result.clearLamp === ClearLamp.Hard,
+                      clear: result && result.clearLamp === ClearLamp.Normal,
+                      'easy-clear':
+                        result && result.clearLamp === ClearLamp.Easy,
+                      'assist-clear':
+                        result && result.clearLamp === ClearLamp.Assist,
+                      failed: result && result.clearLamp === ClearLamp.Failed,
+                    })}
+                  >
+                    {result && result.clearLamp
+                      ? clearTypeTexts[result.clearLamp]
+                      : '-'}
                   </dd>
                 </dl>
-              )}
 
-              <dl className={cx('data-list', 'clear-type')}>
-                <dt>CLEAR TYPE</dt>
-                <dd
-                  className={cx({
-                    'full-combo':
-                      result && result.clearLamp === ClearLamp.FullCombo,
-                    'ex-hard-clear':
-                      result && result.clearLamp === ClearLamp.ExHard,
-                    'hard-clear': result && result.clearLamp === ClearLamp.Hard,
-                    clear: result && result.clearLamp === ClearLamp.Normal,
-                    'easy-clear': result && result.clearLamp === ClearLamp.Easy,
-                    'assist-clear':
-                      result && result.clearLamp === ClearLamp.Assist,
-                    failed: result && result.clearLamp === ClearLamp.Failed,
-                  })}
-                >
-                  {result && result.clearLamp
-                    ? clearTypeTexts[result.clearLamp]
-                    : '-'}
-                </dd>
-              </dl>
-
-              <dl className={cx('data-list')}>
-                <dt>LAST PLAY</dt>
-                <dd className={cx('moderate')}>-</dd>
-              </dl>
+                <dl className={cx('data-list')}>
+                  <dt>LAST PLAY</dt>
+                  <dd className={cx('moderate')}>-</dd>
+                </dl>
+              </div>
             </div>
-          </div>
 
-          <div className={cx('symbol-area')}>
-            <div className={cx('grade-box')}>
-              <div className={cx('current-grade')}>{current.grade}</div>
-              <div className={cx('around-grade')}>
-                {current.diff === 0 && next.diff === 0
-                  ? '-'
-                  : current.diff <= -next.diff
-                  ? `${current.grade} +${current.diff}`
-                  : `${next.grade} ${next.diff}`}
+            <div className={cx('symbol-area')}>
+              <div className={cx('grade-box')}>
+                <div className={cx('current-grade')}>{current.grade}</div>
+                <div className={cx('around-grade')}>
+                  {current.diff === 0 && next.diff === 0
+                    ? '-'
+                    : current.diff <= -next.diff
+                    ? `${current.grade} +${current.diff}`
+                    : `${next.grade} ${next.diff}`}
+                </div>
               </div>
             </div>
           </div>
-        </div>
 
-        {href && (
-          <Link href={href}>
-            <a>
-              <FontAwesomeIcon icon={faAngleRight} />
-            </a>
-          </Link>
-        )}
+          {href && (
+            <Link href={href}>
+              <a>
+                <FontAwesomeIcon icon={faAngleRight} />
+              </a>
+            </Link>
+          )}
+        </div>
       </div>
-    </div>
-  )
+    )
+  }
 }
 
 export default ResultBox

--- a/frontend/src/components/molecules/ResultBox/style.scss
+++ b/frontend/src/components/molecules/ResultBox/style.scss
@@ -1,4 +1,5 @@
 @import 'styles/colors';
+@import 'styles/mixins';
 @import 'styles/variables';
 
 $clear-lamp-width: 0.4rem;
@@ -209,4 +210,8 @@ $top-bottom-padding: 1rem;
   color: lighten($primary-fg-color, 30%);
   font-size: 1.5em;
   text-align: center;
+}
+
+.loading {
+  @include skeleton-loading;
 }

--- a/frontend/src/components/molecules/ResultTable/index.tsx
+++ b/frontend/src/components/molecules/ResultTable/index.tsx
@@ -1,12 +1,11 @@
 import * as classnames from 'classnames/bind'
 import * as _ from 'lodash'
-import Link from 'next/link'
 import * as React from 'react'
 
 import Card from '@app/components/atoms/Card'
 import ResultBox, { Result } from '@app/components/molecules/ResultBox'
 import { Difficulty, PlayStyle } from '@app/queries'
-import routes from '@app/routes'
+import routes, { Link } from '@app/routes'
 import * as css from './style.scss'
 
 const cx = classnames.bind(css)
@@ -79,7 +78,7 @@ const ResultTable: React.SFC<Props> = ({
 
               return (
                 <div className={cx('card')} key={map.id}>
-                  <Link href={href}>
+                  <Link route={href}>
                     <a className={cx('card-link')}>
                       <Card
                         header={

--- a/frontend/src/components/molecules/ResultTable/index.tsx
+++ b/frontend/src/components/molecules/ResultTable/index.tsx
@@ -1,4 +1,5 @@
 import * as classnames from 'classnames/bind'
+import * as _ from 'lodash'
 import Link from 'next/link'
 import * as React from 'react'
 
@@ -16,6 +17,7 @@ export type Music = {
 }
 
 export type Map = {
+  id: string
   numNotes: number
   level: number
   difficulty: Difficulty
@@ -24,67 +26,91 @@ export type Map = {
   music: Music
 }
 
+type Data =
+  | {
+      loading: true
+      numDummyMaps: number
+    }
+  | {
+      loading: false
+      maps: Map[]
+    }
+
 export type Props = {
-  maps: Map[]
+  data: Data
   screenName: string
   showBPI?: boolean
-  totalPages?: number
-  activePage?: number
-  onPageChange?: (newActivePage: number) => void
 }
 
 const ResultTable: React.SFC<Props> = ({
-  maps,
+  data,
   showBPI = false,
   screenName,
 }) => {
   return (
     <>
       <div className={cx('result-table')}>
-        {maps.map((map, i) => {
-          const { result, music } = map
+        {data.loading
+          ? _.range(data.numDummyMaps).map(n => (
+              <div className={cx('card')} key={n}>
+                <Card
+                  header={
+                    <div className={cx('header')}>
+                      <div className={cx('label', 'loading')}>-</div>
+                      <div className={cx('title', 'loading')} />
+                    </div>
+                  }
+                  content={<ResultBox showBPI data={{ loading: true }} />}
+                  clickable={false}
+                />
+              </div>
+            ))
+          : data.maps.map(map => {
+              const { result, music } = map
 
-          // The type of routes.findAndGetUrls is not defined,
-          // so routes should cast to any
-          const href = (routes as any).findAndGetUrls('map', {
-            screenName,
-            musicId: music.id,
-            playStyle: map.playStyle.toLowerCase(),
-            difficulty: map.difficulty.toLowerCase(),
-          }).urls.as
+              // The type of routes.findAndGetUrls is not defined,
+              // so routes should cast to any
+              const href = (routes as any).findAndGetUrls('map', {
+                screenName,
+                musicId: music.id,
+                playStyle: map.playStyle.toLowerCase(),
+                difficulty: map.difficulty.toLowerCase(),
+              }).urls.as
 
-          return (
-            <div className={cx('card')}>
-              <Link href={href}>
-                <a className={cx('card-link')}>
-                  <Card
-                    key={i}
-                    header={
-                      <div className={cx('header')}>
-                        <div
-                          className={cx('label', {
-                            'difficulty-another':
-                              map.difficulty === Difficulty.Another,
-                            'difficulty-hyper':
-                              map.difficulty === Difficulty.Hyper,
-                            'difficulty-normal':
-                              map.difficulty === Difficulty.Normal,
-                          })}
-                        >
-                          ☆{map.level}
-                        </div>
-                        <div className={cx('title')}>{music.title}</div>
-                      </div>
-                    }
-                    content={
-                      <ResultBox showBPI={showBPI} result={result} map={map} />
-                    }
-                  />
-                </a>
-              </Link>
-            </div>
-          )
-        })}
+              return (
+                <div className={cx('card')} key={map.id}>
+                  <Link href={href}>
+                    <a className={cx('card-link')}>
+                      <Card
+                        header={
+                          <div className={cx('header')}>
+                            <div
+                              className={cx('label', {
+                                'difficulty-another':
+                                  map.difficulty === Difficulty.Another,
+                                'difficulty-hyper':
+                                  map.difficulty === Difficulty.Hyper,
+                                'difficulty-normal':
+                                  map.difficulty === Difficulty.Normal,
+                              })}
+                            >
+                              ☆{map.level}
+                            </div>
+                            <div className={cx('title')}>{music.title}</div>
+                          </div>
+                        }
+                        content={
+                          <ResultBox
+                            showBPI={showBPI}
+                            data={{ loading: false, result, map }}
+                          />
+                        }
+                      />
+                    </a>
+                  </Link>
+                </div>
+              )
+            })}
       </div>
     </>
   )

--- a/frontend/src/components/molecules/ResultTable/style.scss
+++ b/frontend/src/components/molecules/ResultTable/style.scss
@@ -36,6 +36,10 @@
   &:last-child {
     margin-right: 0;
   }
+
+  &.loading {
+    height: auto;
+  }
 }
 
 .difficulty-normal {
@@ -56,4 +60,15 @@
 
   white-space: nowrap;
   text-overflow: ellipsis;
+
+  &.loading {
+    flex: 0 0 auto;
+    width: 70%;
+  }
+}
+
+.loading {
+  @include skeleton-loading;
+
+  height: 1em;
 }

--- a/frontend/src/components/organisms/FilterForm/index.tsx
+++ b/frontend/src/components/organisms/FilterForm/index.tsx
@@ -10,7 +10,7 @@ import Button from '@app/components/atoms/Button'
 import Checkbox from '@app/components/atoms/Checkbox'
 import Container from '@app/components/atoms/Container'
 import FormGroup from '@app/components/atoms/FormGroup'
-import { Difficulty, PlayStyle } from '@app/queries'
+import { Difficulty } from '@app/queries'
 
 import * as css from './style.scss'
 

--- a/frontend/src/components/organisms/MapDetail/index.tsx
+++ b/frontend/src/components/organisms/MapDetail/index.tsx
@@ -111,7 +111,7 @@ const MapDetail: React.SFC<Props> = ({ music, map, result }) => (
 
     <Box>
       <div className={cx('result-box-header')}>BEST SCORE</div>
-      <ResultBox showBPI result={result} map={map} />
+      <ResultBox showBPI data={{ loading: false, result, map }} />
     </Box>
   </>
 )

--- a/frontend/src/components/organisms/ResultList/index.tsx
+++ b/frontend/src/components/organisms/ResultList/index.tsx
@@ -38,6 +38,8 @@ const ResultList: React.SFC<Props> = ({
     }
   }
 
+  const offset = (activePage - 1) * numItemsPerPage
+
   return (
     <Container>
       <div className={cx('result-list')}>
@@ -49,26 +51,21 @@ const ResultList: React.SFC<Props> = ({
               playStyle,
               difficulties,
               levels,
+              limit: numItemsPerPage,
+              offset,
             }}
           >
             {({ loading, error, data }) => {
               if (loading) {
                 return 'loading'
               }
-              if (error || !data || !data.searchMaps) {
+              if (error || !data) {
                 return <ErrorPage statusCode={404} />
               }
 
-              const maps = _.map(data.searchMaps, ({ result, ...map }) => ({
-                ...map,
-                result,
-              }))
+              const { totalCount, nodes } = data.searchMaps
 
-              const totalPages = Math.ceil(maps.length / numItemsPerPage)
-              const partialMaps = maps.slice(
-                (activePage - 1) * numItemsPerPage,
-                activePage * numItemsPerPage,
-              )
+              const totalPages = Math.ceil(totalCount / numItemsPerPage)
 
               const pagination = (
                 <Pagination
@@ -81,11 +78,7 @@ const ResultList: React.SFC<Props> = ({
               return (
                 <>
                   <div className={cx('pagination', 'top')}>{pagination}</div>
-                  <ResultTable
-                    showBPI
-                    maps={partialMaps}
-                    screenName={screenName}
-                  />
+                  <ResultTable showBPI maps={nodes} screenName={screenName} />
                   <div className={cx('pagination', 'bottom')}>{pagination}</div>
                 </>
               )

--- a/frontend/src/components/organisms/ResultList/index.tsx
+++ b/frontend/src/components/organisms/ResultList/index.tsx
@@ -5,9 +5,7 @@ import * as React from 'react'
 
 import Container from '@app/components/atoms/Container'
 import Pagination from '@app/components/atoms/Pagination'
-import ResultTable, {
-  Props as ResultTableProps,
-} from '@app/components/molecules/ResultTable'
+import ResultTable from '@app/components/molecules/ResultTable'
 import { FormValues } from '@app/components/organisms/FilterForm'
 import {
   GetUserResultsComponent,
@@ -25,7 +23,7 @@ export type Props = {
   screenName: string
   activePage: number
   numItemsPerPage?: number
-  onPageChange?: ResultTableProps['onPageChange']
+  onPageChange?: (newActivePage: number) => void
 }
 
 function usePrevious<T>(value: T) {
@@ -119,7 +117,11 @@ const ResultList: React.SFC<Props> = ({
                       )
                     }
                   >
-                    loading...
+                    <ResultTable
+                      showBPI
+                      data={{ loading: true, numDummyMaps: numItemsPerPage }}
+                      screenName={screenName}
+                    />
                   </PaginationContainer>
                 )
               }
@@ -148,7 +150,11 @@ const ResultList: React.SFC<Props> = ({
                     />
                   }
                 >
-                  <ResultTable showBPI maps={nodes} screenName={screenName} />
+                  <ResultTable
+                    showBPI
+                    data={{ loading: false, maps: nodes }}
+                    screenName={screenName}
+                  />
                 </PaginationContainer>
               )
             }}

--- a/frontend/src/components/organisms/ResultList/index.tsx
+++ b/frontend/src/components/organisms/ResultList/index.tsx
@@ -32,9 +32,19 @@ const ResultList: React.SFC<Props> = ({
   numItemsPerPage = 20,
   activePage,
 }) => {
+  const containerElement = React.useRef<HTMLDivElement | null>(null)
+
   const changePage = (newActivePage: number) => {
     if (onPageChange) {
       onPageChange(newActivePage)
+    }
+
+    if (containerElement && containerElement.current) {
+      const offsetTop = containerElement.current.offsetTop
+
+      if (window.scrollY > offsetTop) {
+        window.scrollTo({ top: offsetTop })
+      }
     }
   }
 
@@ -42,7 +52,7 @@ const ResultList: React.SFC<Props> = ({
 
   return (
     <Container>
-      <div className={cx('result-list')}>
+      <div ref={containerElement} className={cx('result-list')}>
         <div className={cx('table-wrapper')}>
           <GetUserResultsComponent
             variables={{

--- a/frontend/src/queries/getUserResults.graphql
+++ b/frontend/src/queries/getUserResults.graphql
@@ -4,30 +4,38 @@ query getUserResults(
   $levels: [Int]
   $playStyle: PlayStyle
   $difficulties: [Difficulty]
+  $offset: Int
+  $limit: Int
 ) {
   searchMaps(
     title: $title
     levels: $levels
     playStyle: $playStyle
     difficulties: $difficulties
+    offset: $offset
+    limit: $limit
   ) {
-    id
-    numNotes
-    level
-    difficulty
-    playStyle
+    totalCount
 
-    music {
+    nodes {
       id
-      title
-    }
+      numNotes
+      level
+      difficulty
+      playStyle
 
-    result(username: $username) {
-      id
-      score
-      missCount
-      clearLamp
-      bpi
+      music {
+        id
+        title
+      }
+
+      result(username: $username) {
+        id
+        score
+        missCount
+        clearLamp
+        bpi
+      }
     }
   }
 }

--- a/frontend/src/queries/index.tsx
+++ b/frontend/src/queries/index.tsx
@@ -127,15 +127,25 @@ export type GetUserResultsVariables = {
   levels?: Maybe<(Maybe<number>)[]>
   playStyle?: Maybe<PlayStyle>
   difficulties?: Maybe<(Maybe<Difficulty>)[]>
+  offset?: Maybe<number>
+  limit?: Maybe<number>
 }
 
 export type GetUserResultsQuery = {
   __typename?: 'Query'
 
-  searchMaps: Maybe<GetUserResultsSearchMaps[]>
+  searchMaps: GetUserResultsSearchMaps
 }
 
 export type GetUserResultsSearchMaps = {
+  __typename?: 'MapList'
+
+  totalCount: number
+
+  nodes: GetUserResultsNodes[]
+}
+
+export type GetUserResultsNodes = {
   __typename?: 'Map'
 
   id: string
@@ -363,28 +373,35 @@ export const GetUserResultsDocument = gql`
     $levels: [Int]
     $playStyle: PlayStyle
     $difficulties: [Difficulty]
+    $offset: Int
+    $limit: Int
   ) {
     searchMaps(
       title: $title
       levels: $levels
       playStyle: $playStyle
       difficulties: $difficulties
+      offset: $offset
+      limit: $limit
     ) {
-      id
-      numNotes
-      level
-      difficulty
-      playStyle
-      music {
+      totalCount
+      nodes {
         id
-        title
-      }
-      result(username: $username) {
-        id
-        score
-        missCount
-        clearLamp
-        bpi
+        numNotes
+        level
+        difficulty
+        playStyle
+        music {
+          id
+          title
+        }
+        result(username: $username) {
+          id
+          score
+          missCount
+          clearLamp
+          bpi
+        }
       }
     }
   }

--- a/frontend/src/styles/mixins.scss
+++ b/frontend/src/styles/mixins.scss
@@ -1,3 +1,42 @@
 @mixin card-box {
   box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
 }
+
+@mixin skeleton-loading {
+  position: relative;
+
+  overflow: hidden;
+
+  background: darken($white, 10%);
+
+  &::before {
+    position: absolute;
+    top: 0;
+    left: 0;
+
+    display: block;
+    width: 100%;
+    height: 100%;
+
+    background: linear-gradient(
+      90deg,
+      transparent,
+      rgba(#fff, 0.5),
+      transparent
+    );
+
+    animation: skeleton-animation 1.2s linear infinite;
+
+    content: '';
+  }
+
+  @keyframes skeleton-animation {
+    0% {
+      transform: translateX(-100%);
+    }
+
+    100% {
+      transform: translateX(100%);
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "lint:all": "yarn run format",
     "lint:backend": "cd backend && bundle exec rubocop",
-    "format": "prettier -l '**/*.{js{,x},ts{,x},json,graphql,y{,a}ml}' '**/.babelrc' '!docs/graphql/*' '!frontend/src/queries/index.tsx' --ignore-path .gitignore",
+    "format": "prettier -l '**/*.{js{,x},ts{,x},json,graphql,y{,a}ml}' '**/.babelrc'",
     "format:fix": "yarn run format --write"
   },
   "husky": {


### PR DESCRIPTION
resolve #893 and resolve #713

preview: https://twitter.com/fohte/status/1152916285879025666

## 開発概要

* `searchMaps` query のページネーションをサーバーサイドでやるようにする
  * 以前はフロントエンドで行っていたが、これにより高速化
* リザルト一覧でのページ遷移時にリスト上部にスクロールするようにする
* リザルト一覧でのページ遷移時のローディング UI を本実装

## ついでにやったシリーズ

* Prettier 対象外ファイルは `.prettierignore` で明示する
  * `gql-gen` の生成ファイルが衝突するため
* リザルト一覧からリザルト詳細ページに遷移するときにフルリロードになっていた問題を修正
