### PR TITLE
ECS ホストインスタンスに SSM Session Manager 経由で SSH 接続するようにする

### DIFF
--- a/terraform/db.tf
+++ b/terraform/db.tf
@@ -10,7 +10,7 @@ resource "aws_db_instance" "main" {
   password               = data.aws_ssm_parameter.db_password.value
   db_subnet_group_name   = aws_db_subnet_group.main.name
   vpc_security_group_ids = [aws_security_group.db.id]
-  publicly_accessible    = true
+  publicly_accessible    = false
 }
 
 resource "aws_db_subnet_group" "main" {
@@ -27,13 +27,6 @@ resource "aws_security_group" "db" {
     to_port         = 3306
     protocol        = "tcp"
     security_groups = [aws_security_group.ecs_host.id]
-  }
-
-  ingress {
-    from_port   = 3306
-    to_port     = 3306
-    protocol    = "tcp"
-    cidr_blocks = local.home_cidrs
   }
 
   egress {

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -107,6 +107,12 @@ resource "aws_iam_role_policy_attachment" "ecs_host" {
   policy_arn = aws_iam_policy.ecs_host.arn
 }
 
+# SSM を有効化するために必要
+resource "aws_iam_role_policy_attachment" "ecs_host_ssm" {
+  role       = aws_iam_policy.ecs_host.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+}
+
 resource "aws_security_group" "ecs_host" {
   name        = "${local.name}.ecs_host"
   description = "ECS Allowed Ports"

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -19,13 +19,9 @@ resource "aws_instance" "ecs_host" {
 
   root_block_device {
     volume_type = "gp2"
-    volume_size = 8
-  }
+    volume_size = 30
 
-  ebs_block_device {
-    volume_type = "gp2"
-    volume_size = 22
-    device_name = "/dev/xvdcz"
+    delete_on_termination = true
   }
 
   tags = {
@@ -101,11 +97,14 @@ data "aws_iam_policy_document" "ecs_host" {
   }
 }
 
-resource "aws_iam_role_policy" "ecs_host" {
-  name = "${local.name}.ecs_host"
-  role = aws_iam_role.ecs_host.name
-
+resource "aws_iam_policy" "ecs_host" {
+  name   = "${local.name}.ecs_host"
   policy = data.aws_iam_policy_document.ecs_host.json
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_host" {
+  role       = aws_iam_policy.ecs_host.name
+  policy_arn = aws_iam_policy.ecs_host.arn
 }
 
 resource "aws_security_group" "ecs_host" {

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -126,20 +126,6 @@ resource "aws_security_group" "ecs_host" {
   }
 
   ingress {
-    from_port   = 3000
-    to_port     = 3000
-    protocol    = "tcp"
-    cidr_blocks = local.home_cidrs
-  }
-
-  ingress {
-    from_port   = 5000
-    to_port     = 5000
-    protocol    = "tcp"
-    cidr_blocks = local.home_cidrs
-  }
-
-  ingress {
     protocol        = "tcp"
     from_port       = 3000
     to_port         = 3000

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -1,6 +1,7 @@
 resource "aws_instance" "ecs_host" {
-  # Amazon Linux AMI 2018.03.h x86_64 ECS HVM GP2
-  ami = "ami-0edf19001c48838c7"
+  # Amazon Linux 2 の ECS Optimized AMI の最新版 (以下のコマンドで取得可能)
+  # $ aws ssm get-parameters --names /aws/service/ecs/optimized-ami/amazon-linux-2/recommended --query 'Parameters[0].Value' --output text | jq -r .image_id
+  ami = "ami-04a735b489d2a0320"
 
   instance_type               = "t2.micro"
   availability_zone           = local.availability_zones[0]

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -126,13 +126,6 @@ resource "aws_security_group" "ecs_host" {
   }
 
   ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = local.home_cidrs
-  }
-
-  ingress {
     from_port   = 3000
     to_port     = 3000
     protocol    = "tcp"

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -20,16 +20,12 @@ resource "aws_instance" "ecs_host" {
   root_block_device {
     volume_type = "gp2"
     volume_size = 8
-
-    delete_on_termination = true
   }
 
   ebs_block_device {
     volume_type = "gp2"
     volume_size = 22
     device_name = "/dev/xvdcz"
-
-    delete_on_termination = true
   }
 
   tags = {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -19,7 +19,6 @@ locals {
     0,
     length(local.all_availability_zones) - 1,
   )
-  home_cidrs = ["220.210.176.220/32"]
 }
 
 data "aws_availability_zones" "available" {

--- a/terraform/templates/user_data.sh
+++ b/terraform/templates/user_data.sh
@@ -3,3 +3,8 @@ cat << EOF >> /etc/ecs/ecs.config
 ECS_CLUSTER=${ecs_cluster}
 ECS_AVAILABLE_LOGGING_DRIVERS=["json-file","awslogs"]
 EOF
+
+# ECS Optimized AMI ではデフォルトで SSM Agent がインストールされていないので
+# 手動でインストールする
+# @see https://docs.aws.amazon.com/ja_jp/systems-manager/latest/userguide/sysman-manual-agent-install.html
+yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm


### PR DESCRIPTION
## 動機

* 自宅の Public IP が固定されていないので、変更されるたびにセキュリティグループの設定を変更するのが面倒
* RDS を Public にしたくない

## 備考

以下のように `~/.ssh/config` に設定を追加すれば `ssh iidxio` で ECS ホストに接続できる。

```ssh
Host iidxio
  User ec2-user
  HostName i-0066e498db1d3b956
  IdentityFile ~/.ssh/fohte.pem
  ProxyCommand sh -c "aws ssm start-session --target %h --document-name AWS-StartSSHSession --parameters 'portNumber=%p'"
```

RDS に接続したいときは、ECS ホストインスタンスを踏み台にする (ポートフォワーディングを使う)。

```sh
ssh -fN -L 3307:iidx-io.cprvvtqs60a1.ap-northeast-1.rds.amazonaws.com:3306 iidxio
mysql -u app -p"$IIDXIO_DB_PASSWORD" --host 127.0.0.1 --port 3307
```