### PR TITLE
chore(backend): 開発環境での DNS rebinding attacks protection を無効化する

### DIFF
--- a/backend/config/environments/development.rb
+++ b/backend/config/environments/development.rb
@@ -62,4 +62,7 @@ Rails.application.configure do
     Bullet.bullet_logger = true
     Bullet.raise = false
   end
+
+  # DNS rebinding attacks protection を無効化する
+  config.hosts = nil
 end


### PR DESCRIPTION
開発環境は DNS rebinding attacks の危険性がないため