### PR TITLE
既存のリザルトより TemporaryResult のほうが新しい場合にリザルトが更新されない問題を修正する

### DIFF
--- a/backend/app/models/temporary_result_converter/processor.rb
+++ b/backend/app/models/temporary_result_converter/processor.rb
@@ -122,7 +122,7 @@ module TemporaryResultConverter
 
     def to_result_log(temp_result, map)
       current_result_log = find_result_log(user_id: temp_result.user_id, map: map, last_played_at: temp_result.last_played_at)
-      return if !current_result_log.nil? && current_result_log.last_played_at <= temp_result.last_played_at
+      return unless current_result_log.nil?
 
       result_log = ResultLog.new(
         user_id: temp_result.user_id,

--- a/backend/app/models/temporary_result_converter/processor.rb
+++ b/backend/app/models/temporary_result_converter/processor.rb
@@ -28,7 +28,13 @@ module TemporaryResultConverter
           results = uniq_results(results)
 
           results.each { |r| r.run_callbacks(:save) }
-          Result.import(results)
+          Result.import(results, on_duplicate_key_update: %i[
+            score
+            grade
+            miss_count
+            clear_lamp
+            last_played_at
+          ],)
         end
 
         unless result_logs.empty?
@@ -81,17 +87,27 @@ module TemporaryResultConverter
 
     def to_result(temp_result, map)
       current_result = find_result(user_id: temp_result.user_id, map: map)
-      return unless current_result.nil?
 
-      Result.new(
-        user_id: temp_result.user_id,
-        result_batch_id: temp_result.result_batch_id,
-        map: map,
+      new_attributes = {
         score: temp_result.score,
         miss_count: temp_result.miss_count,
         clear_lamp: temp_result.clear_lamp,
         last_played_at: temp_result.last_played_at,
+      }
+
+      result = Result.new(
+        user_id: temp_result.user_id,
+        result_batch_id: temp_result.result_batch_id,
+        map: map,
+        **new_attributes,
       )
+
+      return result if current_result.nil?
+
+      return unless current_result < result
+
+      current_result.assign_attributes(new_attributes)
+      current_result
     end
 
     def find_result_log(user_id:, map:, last_played_at:)

--- a/backend/lib/tasks/oneshot/update_results_from_logs.rake
+++ b/backend/lib/tasks/oneshot/update_results_from_logs.rake
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+namespace :oneshot do
+  task update_results_from_logs: :environment do
+    ActiveRecord::Base.transaction do
+      Result.includes(:user, :map).where(user_id: 1).find_in_batches do |results|
+        results.each do |result|
+          result_log = ResultLog.where(
+            user: result.user,
+            map: result.map,
+          ).last
+
+          next if result_log.nil?
+          next if result_log.last_played_at < result.last_played_at
+
+          result.assign_attributes(
+            score: result_log.score,
+            miss_count: result_log.miss_count,
+            clear_lamp: result_log.clear_lamp,
+            last_played_at: result_log.last_played_at,
+          )
+
+          result.run_callbacks(:save)
+        end
+
+        Result.import results.select(&:changed?).to_a, on_duplicate_key_update: %i[score miss_count clear_lamp last_played_at grade]
+      end
+    end
+  end
+end


### PR DESCRIPTION
fix #1150