### PR TITLE
textage_crawler: meta_bit に欠損があるときもエラーにしないようにする

### DIFF
--- a/backend/.rubocop.yml
+++ b/backend/.rubocop.yml
@@ -70,7 +70,7 @@ RSpec/LetSetup:
   Enabled: false
 
 Style/NumericPredicate:
-  Enabled: false
+  EnforcedStyle: comparison
 
 Naming/UncommunicativeMethodParamName:
   Enabled: false

--- a/backend/lib/textage/pages/ac_table/map.rb
+++ b/backend/lib/textage/pages/ac_table/map.rb
@@ -9,15 +9,15 @@ module Textage
         attr_accessor :level, :meta_bit, :sub_data
 
         def exist_bms?
-          (meta_bit & 1).nonzero?
+          meta_bit & 1 != 0
         end
 
         def textage_leveling?
-          (meta_bit & 2).zero?
+          meta_bit & 2 == 0
         end
 
         def cn?
-          (meta_bit & 8).nonzero?
+          meta_bit & 8 != 0
         end
 
         def hcn?

--- a/backend/lib/textage/pages/ac_table/map_table.rb
+++ b/backend/lib/textage/pages/ac_table/map_table.rb
@@ -66,7 +66,7 @@ module Textage
         def all_maps
           @all_maps ||=
             raw_array[1, 22].each_slice(2).map do |level, meta_bit|
-              ACTable::Map.new(level: level, meta_bit: meta_bit, sub_data: raw_array[23])
+              ACTable::Map.new(level: level, meta_bit: meta_bit.to_i, sub_data: raw_array[23])
             end
         end
       end

--- a/backend/lib/textage/pages/title_table/music.rb
+++ b/backend/lib/textage/pages/title_table/music.rb
@@ -35,7 +35,7 @@ module Textage
         end
 
         def in_ac?
-          version.nonzero?
+          version != 0
         end
 
         def model_title


### PR DESCRIPTION
fix #1237 