### PR TITLE
fix(frontend): FilterForm の Clear ボタンが改行されてしまう問題を修正する

### DIFF
--- a/frontend/src/components/organisms/FilterForm/index.tsx
+++ b/frontend/src/components/organisms/FilterForm/index.tsx
@@ -225,7 +225,12 @@ const FilterForm: React.SFC<Props> = ({
                     >
                       Clear
                     </Button>
-                    <Button color="primary" type="submit">
+                    <Button
+                      className={cx('submit-button')}
+                      color="primary"
+                      type="submit"
+                      expand={false}
+                    >
                       Submit
                     </Button>
                   </div>

--- a/frontend/src/components/organisms/FilterForm/style.scss
+++ b/frontend/src/components/organisms/FilterForm/style.scss
@@ -80,6 +80,10 @@ $bg-color: $white;
   margin-right: 1rem;
 }
 
+.submit-button {
+  flex: 1;
+}
+
 .form-group-label {
   margin-bottom: 1rem;
 


### PR DESCRIPTION
| old | new |
| --- | --- |
| ![iidx io_@fohte_sp_musics(iPhone 5_SE)](https://user-images.githubusercontent.com/11088009/68524618-6065da00-030c-11ea-8f50-1d4b0d2d2499.png) | ![localhost_3000_@fohte_sp_musics_page=4(iPhone 5_SE)](https://user-images.githubusercontent.com/11088009/68524642-9b680d80-030c-11ea-9906-254b558e1f7b.png) |