### PR TITLE
FilterForm のバグ修正

### DIFF
--- a/frontend/src/components/organisms/FilterForm/index.tsx
+++ b/frontend/src/components/organisms/FilterForm/index.tsx
@@ -16,7 +16,7 @@ import FormGroup from '@app/components/atoms/FormGroup'
 import { Difficulty, Grade } from '@app/queries'
 import { formats } from '@app/lib/dateTime'
 import withClassComponent from '@app/lib/withClassComponent'
-import { FilterFormValueType } from '@app/models/FilterFormValue'
+import { FilterFormValueType, resetValues } from '@app/models/FilterFormValue'
 import FilterFormContext from '@app/contexts/FilterFormContext'
 import { UPDATE_VALUES } from '@app/reducers/filterFormReducer'
 
@@ -212,10 +212,7 @@ const FilterForm: React.SFC<Props> = ({ onCloseRequested }) => {
                       expand={false}
                       type="button"
                       onClick={() => {
-                        form.reset({
-                          difficulties: [],
-                          levels: [],
-                        })
+                        form.reset(resetValues())
                       }}
                     >
                       Clear

--- a/frontend/src/models/FilterFormValue/index.ts
+++ b/frontend/src/models/FilterFormValue/index.ts
@@ -71,6 +71,10 @@ export const toQueryParams = (
 ): FilterFormValueQueryParams => {
   const newQuery: FilterFormValueQueryParams = {}
 
+  if (formValues.levels && formValues.levels.length !== 0) {
+    newQuery.levels = ensureArray(formValues.levels).map(l => l.toString())
+  }
+
   if (formValues.difficulties && formValues.difficulties.length !== 0) {
     newQuery.difficulties = ensureArray(
       formValues.difficulties,

--- a/frontend/src/models/FilterFormValue/index.ts
+++ b/frontend/src/models/FilterFormValue/index.ts
@@ -15,14 +15,16 @@ export interface FilterFormValueType {
   updatedOn?: Date | null
 }
 
-export const defaultValues: Readonly<FilterFormValueType> = {
+export const resetValues = (): FilterFormValueType => ({
   title: null,
   difficulties: [],
   levels: [],
   grades: [],
   onlyUpdated: false,
   updatedOn: null,
-}
+})
+
+export const defaultValues: Readonly<FilterFormValueType> = resetValues()
 
 export type FilterFormValueQueryParams = {
   [key in keyof FilterFormValueType]?: QueryParam


### PR DESCRIPTION
* #1369 でのデグレを修正 (bb3f669f52c5a767711837e060c09b73ae1cc3ba)
* `grades` を追加したタイミングで form の reset 時に `grades` が空になってしまっていた問題を修正 (9021de7185e563941f5a2f43cf6bf2c1031b6f8e)